### PR TITLE
Properly convert quakenet username to lowercase.

### DIFF
--- a/challengeauth.py
+++ b/challengeauth.py
@@ -105,7 +105,7 @@ def get_server_buffer(server):
 
 
 def quakenet_lowercase(string):
-    lowercase_string = string
+    lowercase_string = string.lower()
 
     # was specified https://www.quakenet.org/development/challengeauth
     lower_symbols = {


### PR DESCRIPTION
I just migrated from challengeauth.rb to your script because weechat was not happy with newer versions of ruby[1], and I saw that my login request was not accepted.
Turns out that in challengeauth.rb, the username is lowered at line 57, and this script is not doing it.

Here is a simple proposed fix to lower your username.

[1]: The relevant Github issue can be found at https://github.com/weechat/weechat/issues/1631